### PR TITLE
avoid endless loops if size of slider or step is 0

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -197,8 +197,10 @@ Powerange.prototype.step = function(sliderSize, handleSize) {
     , interval = percentage.of(part, dimension)
     , steps = [];
 
-  for (i = 0; i <= dimension; i += interval) {
-    steps.push(i);
+  if (interval*dimension > 0) {
+    for (i = 0; i <= dimension; i += interval) {
+      steps.push(i);
+    }
   }
 
   this.steps = steps;


### PR DESCRIPTION
I really loved the cleanliness of this plugin, however, running it without css crashed my browser, and when I have investigated, it boiled down to the endless loop that is happening if interval is 0.

I would like to start with an apology: couldn't build your project. not even using the recommended build flow.
after a lot of playing around, got to this:

``` shell
$ component install components/events

       error : no remote found for dependency "components/events".

$ component build components/events
       build : resolved in 38ms
$ grunt build
Running "componentbuild:development" (componentbuild) task
.
Fatal error: failed to lookup "powerange"'s dependency "component-events"
```

The point: 

The proposed fix is laid out the way it is for completeness. it protects from theoretical negative and positive values to any of the variables `interval` and `dimension`, as well as zero interval, which causes infinite loops.

WDYT?
